### PR TITLE
fix: Replace all my.epitech.eu URLs with myresults.epitest.eu

### DIFF
--- a/Enhanced Mouli/Chrome/manifest.json
+++ b/Enhanced Mouli/Chrome/manifest.json
@@ -12,12 +12,12 @@
     "storage"
   ],
   "host_permissions": [
-    "https://my.epitech.eu/*",
+    "https://myresults.epitest.eu/*",
     "https://api.epitest.eu/*"
   ],
   "content_scripts": [
     {
-      "matches": ["https://my.epitech.eu/*"],
+      "matches": ["https://myresults.epitest.eu/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }

--- a/Enhanced Mouli/Firefox/manifest.json
+++ b/Enhanced Mouli/Firefox/manifest.json
@@ -12,12 +12,12 @@
     "storage"
   ],
   "host_permissions": [
-    "https://my.epitech.eu/*",
+    "https://myresults.epitest.eu/*",
     "https://api.epitest.eu/*"
   ],
   "content_scripts": [
     {
-      "matches": ["https://my.epitech.eu/*"],
+      "matches": ["https://myresults.epitest.eu/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }

--- a/Mouli Rework/Chrome/js/better_view.js
+++ b/Mouli Rework/Chrome/js/better_view.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!apiToken) {
     redirectToError(
       "missing",
-      "No authentication token found. Please return to my.epitech.eu and try again.",
+      "No authentication token found. Please return to myresults.epitest.eu and try again.",
       null
     );
   } else {

--- a/Mouli Rework/Chrome/js/details.js
+++ b/Mouli Rework/Chrome/js/details.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!apiToken) {
     redirectToError(
       "missing",
-      "No authentication token found. Please return to my.epitech.eu and try again.",
+      "No authentication token found. Please return to myresults.epitest.eu and try again.",
       null
     );
   } else {

--- a/Mouli Rework/Chrome/js/error.js
+++ b/Mouli Rework/Chrome/js/error.js
@@ -56,7 +56,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   loginButton.addEventListener("click", () => {
-    window.location.href = "https://my.epitech.eu/";
+    window.location.href = "https://myresults.epitest.eu/";
   });
 
   if (returnUrl) {

--- a/Mouli Rework/Chrome/js/history.js
+++ b/Mouli Rework/Chrome/js/history.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!apiToken) {
     redirectToError(
       "missing",
-      "No authentication token found. Please return to my.epitech.eu and try again.",
+      "No authentication token found. Please return to myresults.epitest.eu and try again.",
       null
     );
   } else {

--- a/Mouli Rework/Chrome/manifest.json
+++ b/Mouli Rework/Chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Mouli Rework",
   "version": "1.0.3",
-  "description": "Adds a button to my.epitech.eu to open a custom Moulinette view with dashboard, details and history.",
+  "description": "Adds a button to myresults.epitest.eu to open a custom Moulinette view with dashboard, details and history.",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
@@ -12,7 +12,7 @@
     "scripting"
   ],
   "host_permissions": [
-    "https://my.epitech.eu/*",
+    "https://myresults.epitest.eu/*",
     "https://api.epitest.eu/*"
   ],
   "background": {
@@ -20,7 +20,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://my.epitech.eu/*"],
+      "matches": ["https://myresults.epitest.eu/*"],
       "js": ["js/content.js"],
       "run_at": "document_idle"
     }
@@ -41,7 +41,7 @@
         "icons/icon16.png",
         "icons/icon48.png"
       ],
-      "matches": [ "https://my.epitech.eu/*" ]
+      "matches": [ "https://myresults.epitest.eu/*" ]
     }
   ]
 }

--- a/Mouli Rework/Firefox/js/better_view.js
+++ b/Mouli Rework/Firefox/js/better_view.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!apiToken) {
     redirectToError(
       "missing",
-      "No authentication token found. Please return to my.epitech.eu and try again.",
+      "No authentication token found. Please return to myresults.epitest.eu and try again.",
       null
     );
   } else {

--- a/Mouli Rework/Firefox/js/details.js
+++ b/Mouli Rework/Firefox/js/details.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!apiToken) {
     redirectToError(
       "missing",
-      "No authentication token found. Please return to my.epitech.eu and try again.",
+      "No authentication token found. Please return to myresults.epitest.eu and try again.",
       null
     );
   } else {

--- a/Mouli Rework/Firefox/js/error.js
+++ b/Mouli Rework/Firefox/js/error.js
@@ -56,7 +56,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   loginButton.addEventListener("click", () => {
-    window.location.href = "https://my.epitech.eu/";
+    window.location.href = "https://myresults.epitest.eu/";
   });
 
   if (returnUrl) {

--- a/Mouli Rework/Firefox/js/history.js
+++ b/Mouli Rework/Firefox/js/history.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!apiToken) {
     redirectToError(
       "missing",
-      "No authentication token found. Please return to my.epitech.eu and try again.",
+      "No authentication token found. Please return to myresults.epitest.eu and try again.",
       null
     );
   } else {

--- a/Mouli Rework/Firefox/manifest.json
+++ b/Mouli Rework/Firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Mouli Rework",
   "version": "1.0.3",
-  "description": "Adds a button to my.epitech.eu to open a custom Moulinette view with dashboard, details and history.",
+  "description": "Adds a button to myresults.epitest.eu to open a custom Moulinette view with dashboard, details and history.",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
@@ -13,7 +13,7 @@
     "storage"
   ],
   "host_permissions": [
-    "https://my.epitech.eu/*",
+    "https://myresults.epitest.eu/*",
     "https://api.epitest.eu/*"
   ],
   "background": {
@@ -21,7 +21,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://my.epitech.eu/*"],
+      "matches": ["https://myresults.epitest.eu/*"],
       "js": ["js/content.js"],
       "run_at": "document_idle"
     }
@@ -42,7 +42,7 @@
         "icons/icon16.png",
         "icons/icon48.png"
       ],
-      "matches": [ "https://my.epitech.eu/*" ]
+      "matches": [ "https://myresults.epitest.eu/*" ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
This PR addresses issue #1.

It just contains a replacement of the base URL from ``my.epitech.eu`` to ``myresults.epitest.eu``, the URL of the API of the website hasn't changed and thus wasn't changed.